### PR TITLE
Added Github Action to auto label

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,13 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          labels-synonyms: '{"gssoc21":["GSSOC","GSSOC21","gssoc","Gssoc","GSSoC"]}'


### PR DESCRIPTION
fixes: #40 
Added github action to auto label issues with gssoc21 label whenever contributor asks to work on issue under GSSOC.